### PR TITLE
Updated for upstream flipperzero 0.69.0 rc. Also cleared warnings.

### DIFF
--- a/co2_sensor.c
+++ b/co2_sensor.c
@@ -126,7 +126,6 @@ int32_t co2_sensor_app(void* p) {
 
     // Declare our variables
     PluginEvent tsEvent;
-    bool sensorFound = false;
     float celsius, humidity = 0.0;
     uint16_t co2 = 0;
 
@@ -158,8 +157,8 @@ int32_t co2_sensor_app(void* p) {
 
                 notification_message(notifications, &sequence_blink_blue_100);
 
-                snprintf(ts_data_buffer_temperature_c, DATA_BUFFER_SIZE, "%.2f", celsius);
-                snprintf(ts_data_buffer_humidity, DATA_BUFFER_SIZE, "%.2f", humidity);
+                snprintf(ts_data_buffer_temperature_c, DATA_BUFFER_SIZE, "%.2f", (double) celsius);
+                snprintf(ts_data_buffer_humidity, DATA_BUFFER_SIZE, "%.2f", (double) humidity);
                 snprintf(ts_data_buffer_co2, DATA_BUFFER_SIZE, "%d", co2);
             }
         }

--- a/scd4x.c
+++ b/scd4x.c
@@ -965,7 +965,7 @@ bool sendCommand(uint16_t command) {
     return success;
 }
 
-bool recvData(const uint8_t* data, uint8_t size) {
+bool recvData(uint8_t* data, uint8_t size) {
     furi_hal_i2c_acquire(I2C_BUS);
     if(!furi_hal_i2c_is_device_ready(I2C_BUS, SCD4x_ADDRESS, TIMEOUT)) {
         furi_hal_i2c_release(I2C_BUS);

--- a/scd4x.h
+++ b/scd4x.h
@@ -87,7 +87,7 @@ typedef union {
 
 typedef enum { SCD4x_SENSOR_SCD40 = 0, SCD4x_SENSOR_SCD41 } scd4x_sensor_type_e;
 
-bool recvData(const uint8_t* data, uint8_t size);
+bool recvData(uint8_t* data, uint8_t size);
 
 void SCD4x_init(scd4x_sensor_type_e sensorType);
 


### PR DESCRIPTION
Just a bit of tidying to get it working on the current official flipperzero firmware upstream. Barring any further changes, it'll compile on 0.69. Nice.